### PR TITLE
[PF-215] Add cache to experiment save call path

### DIFF
--- a/lib/split/cache.rb
+++ b/lib/split/cache.rb
@@ -19,8 +19,10 @@ module Split
       @cache[namespace][key] = yield
     end
 
-    def self.clear_key(namespace, key)
-      @cache[namespace]&.delete(key)
+    def self.clear_key(key)
+      @cache.keys.each do |namespace|
+        @cache[namespace]&.delete(key)
+      end
     end
   end
 end

--- a/lib/split/cache.rb
+++ b/lib/split/cache.rb
@@ -18,5 +18,9 @@ module Split
 
       @cache[namespace][key] = yield
     end
+
+    def self.clear_key(namespace, key)
+      @cache[namespace]&.delete(key)
+    end
   end
 end

--- a/lib/split/cache.rb
+++ b/lib/split/cache.rb
@@ -20,7 +20,7 @@ module Split
     end
 
     def self.clear_key(key)
-      @cache.keys.each do |namespace|
+      @cache&.keys&.each do |namespace|
         @cache[namespace]&.delete(key)
       end
     end

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -232,9 +232,8 @@ module Split
     end
 
     def reset
-      Split::Cache.clear_key(@name)
-
       Split.configuration.on_before_experiment_reset.call(self)
+      Split::Cache.clear_key(@name)
       alternatives.each(&:reset)
       reset_winner
       Split.configuration.on_experiment_reset.call(self)

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -166,7 +166,7 @@ module Split
     def reset_winner
       redis.hdel(:experiment_winner, name)
       @has_winner = false
-      Split::cache.clear_key(@name)
+      Split::Cache.clear_key(@name)
     end
 
     def start
@@ -232,7 +232,7 @@ module Split
     end
 
     def reset
-      Split::cache.clear_key(@name)
+      Split::Cache.clear_key(@name)
 
       Split.configuration.on_before_experiment_reset.call(self)
       alternatives.each(&:reset)

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -471,9 +471,10 @@ module Split
     end
 
     def experiment_configuration_has_changed?
-      existing_alternatives = load_alternatives_from_redis
-      existing_goals = Split::GoalsCollection.new(@name).load_from_redis
-      existing_metadata = load_metadata_from_redis
+      existing_experiment = ExperimentCatalog.find(@name)
+      existing_alternatives = existing_experiment.alternatives
+      existing_goals = existing_experiment.goals
+      existing_metadata = existing_experiment.metadata
       existing_alternatives.map(&:to_s) != @alternatives.map(&:to_s) ||
         existing_goals != @goals ||
         existing_metadata != @metadata

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -241,7 +241,6 @@ module Split
       Split::cache.clear_key(:experiment_catalog, @name)
       Split::cache.clear_key(:experiment_start_times, @name)
       Split::cache.clear_key(:experiment_configuration, @name)
-
     end
 
     def delete

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -166,7 +166,7 @@ module Split
     def reset_winner
       redis.hdel(:experiment_winner, name)
       @has_winner = false
-      Split::cache.clear_key(:experiment_winner, @name)
+      Split::cache.clear_key(@name)
     end
 
     def start
@@ -232,15 +232,13 @@ module Split
     end
 
     def reset
+      Split::cache.clear_key(@name)
+
       Split.configuration.on_before_experiment_reset.call(self)
       alternatives.each(&:reset)
       reset_winner
       Split.configuration.on_experiment_reset.call(self)
       increment_version
-
-      Split::cache.clear_key(:experiment_catalog, @name)
-      Split::cache.clear_key(:experiment_start_times, @name)
-      Split::cache.clear_key(:experiment_configuration, @name)
     end
 
     def delete

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -476,7 +476,7 @@ module Split
     def experiment_configuration_has_changed?
       existing_experiment_config = fetch_existing_experiment_configuration
 
-      existing_alternatives.map(&:to_s) != existing_experiment_config[:alternatives].map(&:to_s) ||
+      existing_experiment_config[:alternatives].map(&:to_s) != @alternatives.map(&:to_s) ||
         existing_experiment_config[:goals] != @goals ||
         existing_experiment_config[:metadata] != @metadata
     end

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -482,7 +482,7 @@ module Split
     end
 
     def fetch_existing_experiment_configuration
-      Split.cache(experiment_configuration, @name) do
+      Split.cache(:experiment_configuration, @name) do
         {
           alternatives: load_alternatives_from_redis,
           goals: Split::GoalsCollection.new(@name).load_from_redis,

--- a/lib/split/experiment_catalog.rb
+++ b/lib/split/experiment_catalog.rb
@@ -13,10 +13,7 @@ module Split
     end
 
     def self.find(name)
-      Split.cache(:experiment_catalog, name) do
-        return unless Split.redis.exists(name)
-        Experiment.new(name).tap { |exp| exp.load_from_redis }
-      end
+      Experiment.find(name)
     end
 
     def self.find_or_initialize(metric_descriptor, control = nil, *alternatives)

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -28,7 +28,7 @@ describe Split::Cache do
       expect(Time).to receive(:now).and_return(now).exactly(3).times
       Split::Cache.fetch(namespace, :key1) { Time.now }
       Split::Cache.fetch(namespace, :key2) { Time.now }
-      Split::Cache.clear_key(namespace, :key1)
+      Split::Cache.clear_key(:key1)
 
       Split::Cache.fetch(namespace, :key1) { Time.now }
       Split::Cache.fetch(namespace, :key2) { Time.now }

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -21,6 +21,20 @@ describe Split::Cache do
     end
   end
 
+  describe 'clear_key' do
+    before { Split.configuration.cache = true }
+
+    it 'clears the cache' do
+      expect(Time).to receive(:now).and_return(now).exactly(3).times
+      Split::Cache.fetch(namespace, :key1) { Time.now }
+      Split::Cache.fetch(namespace, :key2) { Time.now }
+      Split::Cache.clear_key(namespace, :key1)
+
+      Split::Cache.fetch(namespace, :key1) { Time.now }
+      Split::Cache.fetch(namespace, :key2) { Time.now }
+    end
+  end
+
   describe 'fetch' do
 
     subject { Split::Cache.fetch(namespace, key) { Time.now } }


### PR DESCRIPTION
The experiment save path compares the experiment config in the call with the one stored in redis, and updates it if its different. It makes redis calls in that comparison, which we can avoid by using the cache introduced in our last split change to get experiment config.

Also added clearing of cache on `experiment#reset`. This fixes a small issue where any experiment config changes (like adding a new variant) would need two reboots to go live.